### PR TITLE
Logging

### DIFF
--- a/cdserver/Gemfile
+++ b/cdserver/Gemfile
@@ -25,6 +25,7 @@ gem 'puma', '~> 3.0'
 # gem 'rack-cors'
 
 gem 'knock'
+gem 'lograge'
 gem 'statsd-instrument'
 
 group :development, :test do

--- a/cdserver/Gemfile.lock
+++ b/cdserver/Gemfile.lock
@@ -89,6 +89,10 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    lograge (0.4.1)
+      actionpack (>= 4, < 5.1)
+      activesupport (>= 4, < 5.1)
+      railties (>= 4, < 5.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -204,6 +208,7 @@ DEPENDENCIES
   database_cleaner
   knock
   listen (~> 3.0.5)
+  lograge
   pg (~> 0.18)
   puma (~> 3.0)
   rails (~> 5.0.1)

--- a/cdserver/app/middleware/log_middleware.rb
+++ b/cdserver/app/middleware/log_middleware.rb
@@ -1,0 +1,14 @@
+# middleware to log ip address of requests
+class LogMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = ActionDispatch::Request.new(env)
+    Thread.current[:logged_ip] = request.ip
+    @app.call(env)
+  ensure
+    Thread.current[:logged_ip] = nil
+  end
+end

--- a/cdserver/config/application.rb
+++ b/cdserver/config/application.rb
@@ -28,5 +28,6 @@ module Cdserver
     config.api_only = true
 
     config.middleware.insert_after 'Rails::Rack::Logger', 'MiddlewareHealthcheck'
+    config.middleware.use 'LogMiddleware'
   end
 end

--- a/cdserver/config/initializers/lograge.rb
+++ b/cdserver/config/initializers/lograge.rb
@@ -1,0 +1,10 @@
+Cdserver::Application.configure do
+  config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w(controller action format id)
+    {
+      params: event.payload[:params].except(*exceptions),
+      ip: Thread.current[:logged_ip]
+    }
+  end
+end


### PR DESCRIPTION
* Implements `lograge` gem for logging: it has good adoption, a clean format, and makes customization fairly easy
* adds `LogMiddleware` class so that we can pull ip addresses from requests (see http://rubyjunky.com/cleaning-up-rails-4-production-logging.html)